### PR TITLE
Remove CircleCi workflows and trigger nightly build via script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,14 @@ jobs:
       - deploy:
           name: Deploy to staging
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              echo -ne '\n' | ./scripts/deploy staging
+            if [ -n "${RUN_NIGHTLY_BUILD}" ]; then
+              echo 'skipping deployment: nightly build'
             else
-              echo 'skipping deployment: not on master branch'
+              if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                echo -ne '\n' | ./scripts/deploy staging
+              else
+                echo 'skipping deployment: not on master branch'
+              fi
             fi
       - save_cache:
           name: Store bundle cache
@@ -98,19 +102,3 @@ jobs:
           paths:
             - ~/.yarn-cache
             - node_modules
-
-workflows:
-  version: 2
-  commit:
-    jobs:
-      - build
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build

--- a/scripts/ci/trigger_nightly_build
+++ b/scripts/ci/trigger_nightly_build
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+_circle_token=$1
+
+trigger_build_url=https://circleci.com/api/v1.1/project/github/AppCamps/TeachingPlatform/tree/master?circle-token=${_circle_token}
+
+post_data=$(cat <<EOF
+{
+  "build_parameters": {
+    "RUN_NIGHTLY_BUILD": "true"
+  }
+}
+EOF)
+
+curl \
+--header "Accept: application/json" \
+--header "Content-Type: application/json" \
+--data "${post_data}" \
+--request POST ${trigger_build_url}


### PR DESCRIPTION
It's not possible to get information about the workflow from CircleCI.
Therefore a circleci/config.yml rewrite would be needed to achieve this
behaviour. We now trigger a nightly build via "Heroku Scheduler" on
staging.